### PR TITLE
fix(menu): adjusted navigation arrows height in mobile mode

### DIFF
--- a/src/app/pages/menu/menu.component.scss
+++ b/src/app/pages/menu/menu.component.scss
@@ -28,7 +28,7 @@
     text-decoration: none;
     letter-spacing: 0;
     font-size: 1.1rem;
-    padding: 0 0.5rem 0.6rem;
+    padding: 0 0.5rem 0rem!important;
   }
 
   a.nav-link:focus, a.nav-link.active {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2-quebec/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
In mobile mode, the navigation arrows of the main menu are higher than the navigation links


**What is the new behavior?**
The navigation links are aligned with the arrows by removing extra padding


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
