### PR TITLE
fix(menu-pages): Pages scroll height fix in flex

### DIFF
--- a/src/qcca-theme/qcca-theme.scss
+++ b/src/qcca-theme/qcca-theme.scss
@@ -88,10 +88,17 @@ margin-left: auto;
 display: flex;
 -ms-flex-wrap: wrap;
 flex-wrap: wrap;
+align-content: flex-start;
 height: 100%;
 width: 98%;
-align-content: center;
 margin: auto;
+}
+
+.page {
+    overflow-y: auto!important;
+    overflow-x: auto;
+    height: calc($portal-height-hasMenu-hasHeader - (4 * $igo-margin)); //if no header: $portal-height-hasMenu
+    width: 100%;
 }
 
 .col-6 {
@@ -311,13 +318,6 @@ box-shadow: 0 1px 4px rgb(34 54 84 / 24%);
 }
 
 //** TYPOGRAPHY **//
-
-.page {
-    overflow-y: auto!important;
-    overflow-x: hidden;
-    height: $portal-height-hasMenu-hasHeader; //if no header: $portal-height-hasMenu
-    width: 100%;
-}
 
 a {
 word-break: break-word;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2-quebec/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
In flex mode, the scroll overflow does not scroll down to the bottom of the content


**What is the new behavior?**
The scroll overflow in flex mode does go down to the bottom content + a bottom margin has been added for less confusion.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
