### PR TITLE
refactor: rename IgoAppSearchResultsToolModule to AppSearchResultsToo…

### DIFF
--- a/src/app/pages/portal/panels/panels.module.ts
+++ b/src/app/pages/portal/panels/panels.module.ts
@@ -1,5 +1,5 @@
 import { IgoAppSearchModule } from '@igo2/integration';
-import { IgoAppSearchResultsToolModule } from './search-results-tool/search-results-tool.module';
+import { AppSearchResultsToolModule } from './search-results-tool/search-results-tool.module';
 import { MatCardModule } from '@angular/material/card';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -53,7 +53,7 @@ import { BottomPanelComponent } from './bottompanel/bottompanel.component';
     IgoContextMenuModule,
     IgoAppSearchModule,
     IgoSearchModule.forRoot(),
-    IgoAppSearchResultsToolModule,
+    AppSearchResultsToolModule,
     MatExpansionModule,
     AppFeatureInfoModule,
     AppFeatureModule,

--- a/src/app/pages/portal/panels/search-results-tool/search-results-tool.module.ts
+++ b/src/app/pages/portal/panels/search-results-tool/search-results-tool.module.ts
@@ -38,4 +38,4 @@ import { SearchResultsToolComponent } from './search-results-tool.component';
   exports: [SearchResultsToolComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
-export class IgoAppSearchResultsToolModule {}
+export class AppSearchResultsToolModule {}


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)

this behavior related to #46 

**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
